### PR TITLE
enh: escape table name

### DIFF
--- a/src/main/scala/com/github/caiiiycuk/pg2sqlite/command/CreateTable.scala
+++ b/src/main/scala/com/github/caiiiycuk/pg2sqlite/command/CreateTable.scala
@@ -29,7 +29,7 @@ object CreateTable extends Command with Log {
         schema.addColumn(table, column)
       }
 
-      (table, s"CREATE TABLE $table (${columns.map(column => s"[${column.name}]").mkString(", ")});")
+      (table, s"CREATE TABLE [$table] (${columns.map(column => s"[${column.name}]").mkString(", ")});")
     } catch {
       case t: Throwable =>
         throw CommandException(s"CREATE TABLE - Unable to find TABLE NAME or COLUMNS in '$rawSql'",


### PR DESCRIPTION
fixes: #17 when having a table named "order" it fails to create 