### PR TITLE
Surround index column name with brackets

### DIFF
--- a/src/main/scala/com/github/caiiiycuk/pg2sqlite/command/CreateIndex.scala
+++ b/src/main/scala/com/github/caiiiycuk/pg2sqlite/command/CreateIndex.scala
@@ -26,7 +26,7 @@ object CreateIndex extends Command with Log {
       val createIndexParts = rawSql.split("""\s+on\s+""")
       val indexName = createIndexParts(0).tokens(INDEX_NAME_POSITION)
       val tableName = createIndexParts(1).tokens(TABLE_NAME_POSITION)
-      val columns = rawSql.takeBraces.head.columns.map(_.name).mkString(",")
+      val columns = rawSql.takeBraces.head.columns.map(column => s"[${column.name}]").mkString(",")
 
       (tableName, s"CREATE INDEX $indexName ON $tableName ($columns)", columns)
     } catch {


### PR DESCRIPTION
Surround column name with brackets to avoid issues when the column name is the same as a reserved keyword (e.g. index)